### PR TITLE
shortHelpString URL update

### DIFF
--- a/pcraster_tools/processing/algorithms/col2map.py
+++ b/pcraster_tools/processing/algorithms/col2map.py
@@ -50,7 +50,7 @@ class Col2mapAlgorithm(PCRasterAlgorithm):
     def shortHelpString(self):  # pylint: disable=missing-function-docstring
         return self.tr(
             """
-            Convert CSV files to PCRaster format with control of the output data type. The algorithm uses <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/app_col2map.html">col2map</a>
+            Convert CSV files to PCRaster format with control of the output data type. The algorithm uses <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/app_col2map.html">col2map</a>
             For nominal and ordinal maps you can choose between small and large integers. With small integers you can store values from 0 to 255. Only choose large when you have higher numbers.
             """
         )

--- a/pcraster_tools/processing/algorithms/pcraster_abs_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_abs_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterAbsAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Absolute value
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_abs.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_abs.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_accucapacityflux_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_accucapacityflux_algorithm.py
@@ -48,7 +48,7 @@ class PCRasterAccucapacityfluxAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Transport of material downstream over a local drain direction network
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_accucapacity.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_accucapacity.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_accuflux_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_accuflux_algorithm.py
@@ -46,7 +46,7 @@ class PCRasterAccuFluxAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Accumulated material flowing into downstream cell
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_accuflux.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_accuflux.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_accufractionflux_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_accufractionflux_algorithm.py
@@ -48,7 +48,7 @@ class PCRasterAccufractionfluxAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Fractional material transport downstream over local drain direction network
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_accufraction.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_accufraction.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_accuthresholdflux_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_accuthresholdflux_algorithm.py
@@ -48,7 +48,7 @@ class PCRasterAccuthresholdfluxAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Input of material downstream over a local drain direction network when transport threshold is exceeded
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_accuthreshold.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_accuthreshold.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_accutraveltimeflux_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_accutraveltimeflux_algorithm.py
@@ -48,7 +48,7 @@ class PCRasterAccutraveltimefluxAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Transports material downstream over a distance dependent on a given velocity.
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_accutraveltime.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_accutraveltime.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_accutraveltimefractionflux_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_accutraveltimefractionflux_algorithm.py
@@ -50,7 +50,7 @@ class PCRasterAccutraveltimefractionfluxAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Transports material downstream over a distance dependent on a given velocity.
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_accutraveltimefraction.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_accutraveltimefraction.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_accutriggerflux_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_accutriggerflux_algorithm.py
@@ -48,7 +48,7 @@ class PCRasterAccutriggerfluxAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Input of material downstream over a local drain direction network when transport trigger is exceeded
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_accutrigger.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_accutrigger.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_acos_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_acos_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterAcosAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Inverse cosine
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_acos.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_acos.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_areaarea_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_areaarea_algorithm.py
@@ -47,7 +47,7 @@ class PCRasterAreaareaAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """The area of the area to which a cell belongs
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_areaarea.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_areaarea.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_areaaverage_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_areaaverage_algorithm.py
@@ -46,7 +46,7 @@ class PCRasterAreaaverageAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """The area of the area to which a cell belongs
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_areaaverage.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_areaaverage.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_areadiversity_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_areadiversity_algorithm.py
@@ -46,7 +46,7 @@ class PCRasterAreadiversityAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Number of unique cell values within an area
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_areadiversity.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_areadiversity.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_areamajority_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_areamajority_algorithm.py
@@ -47,7 +47,7 @@ class PCRasterAreamajorityAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Most often occurring cell value within an area
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_areamajority.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_areamajority.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_areamaximum_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_areamaximum_algorithm.py
@@ -46,7 +46,7 @@ class PCRasterAreamaximumAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Maximum cell value within an area
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_areamaximum.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_areamaximum.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_areaminimum_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_areaminimum_algorithm.py
@@ -46,7 +46,7 @@ class PCRasterAreaminimumAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Minimum cell value within an area
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_areaminimum.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_areaminimum.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_areanormal_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_areanormal_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterAreanormalAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Value assigned to an area taken from a normal distribution
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_areanormal.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_areanormal.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_areaorder_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_areaorder_algorithm.py
@@ -46,7 +46,7 @@ class PCRasterAreaorderAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Within each area ordinal numbers to cells in ascending order
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_areaorder.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_areaorder.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_areatotal_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_areatotal_algorithm.py
@@ -46,7 +46,7 @@ class PCRasterAreatotalAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Sum of cell values within an area
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_areatotal.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_areatotal.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_areauniform_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_areauniform_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterAreauniformAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Value assigned to area taken from a uniform distribution
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_areauniform.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_areauniform.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_asin_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_asin_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterAsinAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Inverse sine
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_asin.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_asin.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_aspect_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_aspect_algorithm.py
@@ -46,7 +46,7 @@ class PCRasterAspectAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Aspects of a map using a digital elevation model
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_aspect.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_aspect.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_atan_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_atan_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterAtanAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Inverse tangent
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_atan.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_atan.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_booleanoperators_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_booleanoperators_algorithm.py
@@ -48,7 +48,7 @@ class PCRasterBooleanOperatorsAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Boolean operators
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/secfunclist.html#boolean-operators">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/secfunclist.html#boolean-operators">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_catchment_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_catchment_algorithm.py
@@ -46,7 +46,7 @@ class PCRasterCatchmentAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Catchment(s) of one or more specified cells
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_catchment.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_catchment.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_catchmenttotal_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_catchmenttotal_algorithm.py
@@ -46,7 +46,7 @@ class PCRasterCatchmenttotalAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Total catchment for the entire upstream area
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_catchmenttotal.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_catchmenttotal.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_cellarea_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_cellarea_algorithm.py
@@ -47,7 +47,7 @@ class PCRastercellareaAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Area of one cell
 
-                <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_cellarea.html">PCRaster documentation</a>
+                <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_cellarea.html">PCRaster documentation</a>
 
                 Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_celllength_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_celllength_algorithm.py
@@ -45,7 +45,7 @@ class PCRastercelllengthAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Horizontal and vertical length of a cell
 
-                <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_celllength.html">PCRaster documentation</a>
+                <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_celllength.html">PCRaster documentation</a>
 
                 Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_clump_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_clump_algorithm.py
@@ -47,7 +47,7 @@ class PCRasterClumpAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Contiguous groups of cells with the same value (‘clumps’)
 
-                <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_clump.html">PCRaster documentation</a>
+                <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_clump.html">PCRaster documentation</a>
 
                 Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_comparisonoperators_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_comparisonoperators_algorithm.py
@@ -48,7 +48,7 @@ class PCRasterComparisonOperatorsAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Boolean operators
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/secfunclist.html#comparison-operators">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/secfunclist.html#comparison-operators">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_convertdatatype_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_convertdatatype_algorithm.py
@@ -46,7 +46,7 @@ class PCRasterConvertdatatypeAlgorithm(PCRasterAlgorithm):
     def shortHelpString(self):  # pylint: disable=missing-function-docstring
         return self.tr(
             """
-            Conversion of the layer data type.<a href=https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/secfunclist.html#data-types-conversion-and-assignment>PCRaster documentation</a>
+            Conversion of the layer data type.<a href=https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/secfunclist.html#data-types-conversion-and-assignment>PCRaster documentation</a>
             """
         )
 

--- a/pcraster_tools/processing/algorithms/pcraster_cos_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_cos_algorithm.py
@@ -45,7 +45,7 @@ class PCRastercosAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Cosine
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_cos.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_cos.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_cover_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_cover_algorithm.py
@@ -48,7 +48,7 @@ class PCRasterCoverAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Missing values substituted for values from other raster(s)
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_cover.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_cover.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_defined_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_defined_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterDefinedAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Boolean TRUE for non missing values and FALSE for missing values
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_defined.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_defined.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_downstream_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_downstream_algorithm.py
@@ -46,7 +46,7 @@ class PCRasterDownstreamAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Cell gets value of the neighbouring downstream cell
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_downstream.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_downstream.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_downstreamdist_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_downstreamdist_algorithm.py
@@ -47,7 +47,7 @@ class PCRasterDownstreamdistAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Distance to the first cell downstream
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_downstreamdist.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_downstreamdist.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_exp_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_exp_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterexpAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Base e exponential
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_exp.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_exp.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_extentofview_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_extentofview_algorithm.py
@@ -47,7 +47,7 @@ class PCRasterExtentofviewAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Total length of the lines in a number of directions from the cell under consideration to the first cell with a different value.
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_extentofview.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_extentofview.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_fac_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_fac_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterfacAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Faculty or factorial of a natural positive number
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_fac.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_fac.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_horizontan_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_horizontan_algorithm.py
@@ -47,7 +47,7 @@ class PCRasterHorizontanAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Calculates the maximum tangent of the angles of neighbouring cells in the direction of the sun.
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_horizontan.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_horizontan.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_ifthen_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_ifthen_algorithm.py
@@ -46,7 +46,7 @@ class PCRasterIfThenAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Return missing values if condition is not met.
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_ifthen.html#ifthen">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_ifthen.html#ifthen">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_ifthenelse_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_ifthenelse_algorithm.py
@@ -47,7 +47,7 @@ class PCRasterIfThenElseAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Boolean condition determining whether value of the first or second expression is assigned to result
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_ifthenelse.html#ifthenelse">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_ifthenelse.html#ifthenelse">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_inversedistance_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_inversedistance_algorithm.py
@@ -52,7 +52,7 @@ class PCRasterInversedistanceAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Interpolate values using inverse distance weighting
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_inversedistance.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_inversedistance.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_lddcreate_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_lddcreate_algorithm.py
@@ -53,7 +53,7 @@ class PCRasterLDDCreateAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Local drain direction map with flow directions from each cell to its steepest downslope neighbour
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_lddcreate.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_lddcreate.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_lddcreatedem_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_lddcreatedem_algorithm.py
@@ -54,7 +54,7 @@ class PCRasterLDDCreateDEMAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Modified digital elevation model
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_lddcreatedem.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_lddcreatedem.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_ldddist_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_ldddist_algorithm.py
@@ -49,7 +49,7 @@ class PCRasterLDDDistAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Friction-distance from the cell under consideration to downstream nearest TRUE cell
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_ldddist.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_ldddist.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_lddmask_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_lddmask_algorithm.py
@@ -46,7 +46,7 @@ class PCRasterLddMaskAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Local drain direction map cut into a (smaller) sound local drain direction map
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_lddmask.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_lddmask.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_lddrepair_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_lddrepair_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterlddrepairAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Reparation of unsound local drain direction map
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_lddrepair.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_lddrepair.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_ln_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_ln_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterlnAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Natural logarithm (e)
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_ln.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_ln.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_log10_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_log10_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterlog10Algorithm(PCRasterAlgorithm):
         return self.tr(
             """Log 10
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_log10.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_log10.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_lookup_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_lookup_algorithm.py
@@ -50,7 +50,7 @@ class PCRasterLookupAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Compares cell value(s) of one or more expression(s) with the search key in a table
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_lookup.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_lookup.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_lookuplinear_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_lookuplinear_algorithm.py
@@ -47,7 +47,7 @@ class PCRasterLookuplinearAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Assigns table key values with possible interpolation between key values.
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_lookuplinear.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_lookuplinear.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_maparea_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_maparea_algorithm.py
@@ -47,7 +47,7 @@ class PCRasterMapareaAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Total map area
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_maparea.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_maparea.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_mapmaximum_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_mapmaximum_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterMapmaximumAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Maximum cell value
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_mapmaximum.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_mapmaximum.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_mapminimum_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_mapminimum_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterMapminimumAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Minimum cell value
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_mapminimum.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_mapminimum.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_mapnormal_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_mapnormal_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterMapnormalAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Cells get non spatial value taken from a normal distribution
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_mapnormal.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_mapnormal.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_maptotal_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_maptotal_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterMaptotalAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Sum of all cell values
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_maptotal.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_maptotal.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_mapuniform_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_mapuniform_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterMapuniformAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Cells get non spatial value taken from an uniform distribution
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_mapuniform.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_mapuniform.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_nodirection_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_nodirection_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterNodirectionAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Cells with no direction (e.g. flat) get boolean TRUE and with direction get boolean FALSE
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_nodirection.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_nodirection.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_normal_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_normal_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterNormalAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Boolean TRUE cell gets value taken from a normal distribution
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_normal.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_normal.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_order_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_order_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterorderAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Ordinal numbers to cells in ascending order
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_order.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_order.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_path_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_path_algorithm.py
@@ -46,7 +46,7 @@ class PCRasterPathAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Path over the local drain direction network downstream to its pit
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_path.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_path.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_pit_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_pit_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterPitAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Unique value for each pit cell
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_pit.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_pit.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_plancurv_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_plancurv_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterPlancurvAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Planform curvature calculation using a DEM
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_plancurv.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_plancurv.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_pred_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_pred_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterpredAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Ordinal number of the next lower ordinal class
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_pred.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_pred.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_profcurv_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_profcurv_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterProfcurvAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Profile curvature calculation using a DEM
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_profcurv.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_profcurv.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_rounddown_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_rounddown_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterrounddownAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Rounding down of cell values to whole numbers
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_rounddown.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_rounddown.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_roundoff_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_roundoff_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterroundoffAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Rounding off of cellvalues to whole numbers
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_roundoff.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_roundoff.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_roundup_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_roundup_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterroundupAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Rounding up of cell values to whole numbers
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_roundup.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_roundup.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_sin_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_sin_algorithm.py
@@ -45,7 +45,7 @@ class PCRastersinAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Sine
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_sin.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_sin.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_slope_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_slope_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterSlopeAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Slope of cells using a digital elevation model
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_slope.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_slope.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_slopelength_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_slopelength_algorithm.py
@@ -48,7 +48,7 @@ class PCRasterSlopelengthAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Accumulative-friction-distance of the longest accumulative-friction-path upstream over the local drain direction network cells against waterbasin divides
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_slopelength.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_slopelength.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_spatial_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_spatial_algorithm.py
@@ -49,7 +49,7 @@ class PCRasterSpatialAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Conversion of a non-spatial value to a spatial data type.
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_spatial.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_spatial.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_spread_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_spread_algorithm.py
@@ -49,7 +49,7 @@ class PCRasterSpreadAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Total friction of the shortest accumulated friction path over a map with friction values from a source cell to cell under consideration
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_spread.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_spread.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_spreadldd_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_spreadldd_algorithm.py
@@ -50,7 +50,7 @@ class PCRasterSpreadlddAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Total friction of the shortest accumulated friction downstream path over map with friction values from an source cell to cell under consideration
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_spreadldd.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_spreadldd.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_spreadlddzone_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_spreadlddzone_algorithm.py
@@ -50,7 +50,7 @@ class PCRasterSpreadlddzoneAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Shortest friction-distance path over map with friction from a source cell to cell under consideration, only paths in downstream direction from the source cell are considered
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_spreadlddzone.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_spreadlddzone.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_spreadmax_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_spreadmax_algorithm.py
@@ -51,7 +51,7 @@ class PCRasterSpreadmaxAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Total friction of the shortest accumulated friction path over a map with friction values from a source cell to cell under consideration considering maximum spread distance
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_spreadmax.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_spreadmax.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_spreadmaxzone_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_spreadmaxzone_algorithm.py
@@ -51,7 +51,7 @@ class PCRasterSpreadmaxzoneAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Shortest friction-distance path over a map with friction from an identified source cell or cells to the cell under consideration
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_spreadmaxzone.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_spreadmaxzone.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_spreadzone_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_spreadzone_algorithm.py
@@ -49,7 +49,7 @@ class PCRasterSpreadzoneAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Shortest friction-distance path over a map with friction from an identified source cell or cells to the cell under consideration
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_spreadzone.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_spreadzone.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_sqr_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_sqr_algorithm.py
@@ -45,7 +45,7 @@ class PCRastersqrAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Square
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_sqr.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_sqr.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_sqrt_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_sqrt_algorithm.py
@@ -45,7 +45,7 @@ class PCRastersqrtAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Square root
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_sqrt.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_sqrt.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_streamorder_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_streamorder_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterStreamOrderAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Stream order index of all cells on a local drain direction network
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_streamorder.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_streamorder.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_subcatchment_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_subcatchment_algorithm.py
@@ -46,7 +46,7 @@ class PCRasterSubcatchmentAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """(Sub-)Catchment(s) (watershed, basin) of each one or more specified cells
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_subcatchment.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_subcatchment.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_succ_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_succ_algorithm.py
@@ -45,7 +45,7 @@ class PCRastersuccAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Ordinal number of the next higher ordinal class
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_succ.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_succ.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_tan_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_tan_algorithm.py
@@ -45,7 +45,7 @@ class PCRastertanAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Tangent
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_tan.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_tan.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_transient_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_transient_algorithm.py
@@ -52,7 +52,7 @@ class PCRasterTransientAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Simulates transient groundwater flow according to the implicit finite difference method.
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_transient.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_transient.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_uniform_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_uniform_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterUniformAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Boolean TRUE cell gets value from an uniform distribution
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_uniform.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_uniform.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_uniqueid_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_uniqueid_algorithm.py
@@ -45,7 +45,7 @@ class PCRasterUniqueidAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Unique whole value for each Boolean TRUE cell
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_uniqueid.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_uniqueid.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_upstream_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_upstream_algorithm.py
@@ -46,7 +46,7 @@ class PCRasterUpstreamAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Sum of the cell values of its first upstream cell(s)
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_upstream.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_upstream.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_view_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_view_algorithm.py
@@ -46,7 +46,7 @@ class PCRasterViewAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """TRUE or FALSE value for visibility from viewpoint(s) defined by a digital elevation model
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_view.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_view.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_window4total_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_window4total_algorithm.py
@@ -44,7 +44,7 @@ class PCRasterwindow4totalAlgorithm(PCRasterAlgorithm):
     def shortHelpString(self):  # pylint: disable=missing-function-docstring
         return self.tr(
             """Sum the values of the four surrounding cells.
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_window4total.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_window4total.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_windowaverage_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_windowaverage_algorithm.py
@@ -49,7 +49,7 @@ class PCRasterWindowAverageAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Average of cell values within a specified square neighbourhood
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_windowaverage.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_windowaverage.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_windowdiversity_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_windowdiversity_algorithm.py
@@ -49,7 +49,7 @@ class PCRasterWindowDiversityAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Number of unique values within a specified square neighbourhood
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_windowdiversity.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_windowdiversity.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_windowhighpass_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_windowhighpass_algorithm.py
@@ -49,7 +49,7 @@ class PCRasterWindowHighPassAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Increases spatial frequency within a specified square neighbourhood
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_windowhighpass.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_windowhighpass.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_windowmajority_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_windowmajority_algorithm.py
@@ -49,7 +49,7 @@ class PCRasterWindowMajorityAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Most occurring cell value within a specified square neighbourhood
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_windowmajority.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_windowmajority.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_windowmaximum_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_windowmaximum_algorithm.py
@@ -49,7 +49,7 @@ class PCRasterWindowMaximumAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Maximum cell value within a specified square neighbourhood
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_windowmaximum.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_windowmaximum.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_windowminimum_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_windowminimum_algorithm.py
@@ -49,7 +49,7 @@ class PCRasterWindowMinimumAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Minimum value within a specified square neighbourhood
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_windowminimum.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_windowminimum.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/pcraster_windowtotal_algorithm.py
+++ b/pcraster_tools/processing/algorithms/pcraster_windowtotal_algorithm.py
@@ -49,7 +49,7 @@ class PCRasterWindowTotalAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Sum of values within a specified square neighbourhood
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/op_windowtotal.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/op_windowtotal.html">PCRaster documentation</a>
 
             Parameters:
 

--- a/pcraster_tools/processing/algorithms/resample.py
+++ b/pcraster_tools/processing/algorithms/resample.py
@@ -50,7 +50,7 @@ class ResampleAlgorithm(PCRasterAlgorithm):
         return self.tr(
             """Cuts one map or joins together several maps by resampling to the cells of the result map.
 
-            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.1/documentation/pcraster_manual/sphinx/app_resample.html">PCRaster documentation</a>
+            <a href="https://pcraster.geo.uu.nl/pcraster/4.3.2/documentation/pcraster_manual/sphinx/app_resample.html">PCRaster documentation</a>
 
             Parameters:
 


### PR DESCRIPTION
URL's in shortHelpString of all PCRaster algorithms updated to PCRaster 4.3.2.
Maybe we can automate replacing the link in the future.